### PR TITLE
No Issue | Enabled sort-by-version, making newest-first default.

### DIFF
--- a/BE/src/Services/Packages/Versioning/search-functions.ts
+++ b/BE/src/Services/Packages/Versioning/search-functions.ts
@@ -6,6 +6,20 @@ import { GetPackagesData } from "RequestTypes";
 import semver from "semver";
 import { PackageMetaData } from "../../../Types/Models";
 
+export function SortByVersion(unsorted: Package[], newestFirst: boolean = true): Package[] {
+    if (newestFirst) {
+        // Newest version first
+        return unsorted.sort((left, right) => {
+            return semver.lt(left.metadata.Version, right.metadata.Version) ? 1 : -1;
+        });
+    } else {
+        // Oldest version first
+        return unsorted.sort((left, right) => {
+            return semver.gt(left.metadata.Version, right.metadata.Version) ? 1 : -1;
+        });
+    }
+}
+
 export namespace SearchVersion {
     export async function ByExact(title: string, filter: string): Promise<GetPackagesResponseBody> {
         let result: PackageMetaData[] = [];
@@ -42,11 +56,19 @@ export namespace SearchVersion {
         }
     }
 
-    export async function RetrieveAll(title: string): Promise<GetPackagesResponseBody> {
+    export async function RetrieveAll(
+        title: string,
+        sortByVersion: boolean = true,
+        newestFirst: boolean = true
+    ): Promise<GetPackagesResponseBody> {
         const allVersions = await PackageModel.find(
             { "metadata.Name": title },
             { _id: 1, "metadata.Name": 1, "metadata.Version": 1 }
         ).lean();
+
+        if (sortByVersion) {
+            SortByVersion(allVersions, newestFirst);
+        }
 
         return allVersions.map<PackageMetaData>((doc) => ({
             ID: doc._id.toString(),

--- a/BE/src/index.ts
+++ b/BE/src/index.ts
@@ -21,6 +21,8 @@ import { Auth0_Database } from "./Services/AdminUser/Auth0_DB";
 import { RegistrationInfo } from "./Services/AdminUser/types";
 import { Role } from "./Services/AdminUser/UserData";
 import { calculateCumulativeSize } from "./Services/Packages/Multicost";
+import { FetchVersions, SearchVersion } from "./Services/Packages/Versioning/search-functions";
+import { GetPackagesData } from "RequestTypes";
 
 dotenv.config();
 
@@ -108,6 +110,16 @@ function ManualTestMulticost(packages: string[]) {
     const totalSize = calculateCumulativeSize(packages, packageManager);
 
     console.log(`Total size cost for packages [${packages.join(", ")}]: ${totalSize / 1024} KB`);
+}
+
+async function ManualTestVersionSort() {
+    const req: GetPackagesData[] = [
+        {
+            Name: "JP",
+            Version: "2.0.0-6.0.0",
+        },
+    ];
+    console.log(await FetchVersions(req));
 }
 
 async function Execute() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/eac064c7-73ca-4c94-8da4-5220d097c536)

Improves user quality of life by adding sort-by-version functionality to package fetch. Default option is newest first (aka descending or stack order). Also supports ascending / queue order / chronological sort, but only in direct vsearch calls. 

In other words, that option is only available when a call is made directly to, for example ByTIlde, instead of the general functions that deduce which type of search to apply. 